### PR TITLE
Animated textures implementation for blocks

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -21,11 +21,11 @@ wrapper = mcpython.LaunchWrapper.LaunchWrapper()
 
 
 if __name__ == "__main__":
+    wrapper.set_client()
     wrapper.apply_mixins()
     wrapper.check_py_version()
 
     try:
-        wrapper.set_client()
         wrapper.full_launch()
 
     except (SystemExit, KeyboardInterrupt):

--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -77,7 +77,18 @@ UI:
 -> Round button corners & colors
 -> World selection list round white outline 
 
-Test System:
+### Dedicated servers
+- Don't require Pillow and pyglet on dedicated servers
+- Make compatible with python 3.11
+
+### Runtime optimisation
+- Write a mixin using system with helper function "if decide_hard(<string flag>): <do stuff>", which will eval 
+    the expression at each reload and remove the opcodes of that section when the flag is not set
+- Same goes for shared.IS_CLIENT checks, they can be stripped away / removed
+- This can be used in TickHandler for deciding ticks
+- This can be used to configure rendering code
+
+### Test System
 The test system is an external tool developed along the game sitting on top of it. It uses
 a) The python import system, for loading single files and providing dummy files
 b) The custom LaunchWrapper system, for launching the game in-code

--- a/doc/version.info
+++ b/doc/version.info
@@ -1940,12 +1940,3 @@ A** [uuk]: For optimisation reasons, the show_face() and hide_face() method of F
 fA  [uuk]: model system allows now all parties to add directly to the batch
 f   [uuk]: implemented AnimationManager for animated block textures, using above system
 
-pending:
-- per-animated-texture texture coords calculation as atlas size may vary
--> reduce memory usage
-
-- pyglet does not like what we are doing to animate textures, so can we do something else?
-(currently, I have some hacks locally to make pyglet semi-happy)
-
-- somehow, adding somewhere a new block affects other blocks
-

--- a/doc/version.info
+++ b/doc/version.info
@@ -1938,4 +1938,14 @@ IA* [uuk]: FaceInfo will now use two ints to represent the visual state of the b
 A** [uuk]: For optimisation reasons, the show_face() and hide_face() method of FaceInfo are now removed;
            The only way is to invoke show_faces() and hide_faces() with the bit flag of the face
 fA  [uuk]: model system allows now all parties to add directly to the batch
+f   [uuk]: implemented AnimationManager for animated block textures, using above system
+
+pending:
+- per-animated-texture texture coords calculation as atlas size may vary
+-> reduce memory usage
+
+- pyglet does not like what we are doing to animate textures, so can we do something else?
+(currently, I have some hacks locally to make pyglet semi-happy)
+
+- somehow, adding somewhere a new block affects other blocks
 

--- a/launch_server.py
+++ b/launch_server.py
@@ -23,6 +23,7 @@ wrapper = mcpython.LaunchWrapper.LaunchWrapper()
 
 
 if __name__ == "__main__":
+    wrapper.set_server()
     wrapper.apply_mixins()
     wrapper.check_py_version()
 
@@ -42,7 +43,6 @@ if __name__ == "__main__":
     )
 
     try:
-        wrapper.set_server()
         wrapper.full_launch()
     except (SystemExit, KeyboardInterrupt):
         raise

--- a/mcpython/LaunchWrapper.py
+++ b/mcpython/LaunchWrapper.py
@@ -53,10 +53,10 @@ class LaunchWrapper:
             )
 
     def set_client(self):
-        self.is_client = True
+        self.is_client = shared.IS_CLIENT = True
 
     def set_server(self):
-        self.is_client = False
+        self.is_client = shared.IS_CLIENT = False
 
     def apply_mixins(self):
         import mcpython.util.libmodifiers

--- a/mcpython/client/rendering/blocks/FluidRenderer.py
+++ b/mcpython/client/rendering/blocks/FluidRenderer.py
@@ -21,6 +21,7 @@ from mcpython.client.rendering.model.BoxModel import ColoredRawBoxModel
 
 # Used to prevent z-fighting with neighbor blocks on transparent fluids
 from mcpython.engine import logger
+import mcpython.util.enums
 
 SOME_SMALL_VALUES = 1 / 1000
 
@@ -82,10 +83,10 @@ class FluidRenderer(
             batches[1], block.position, face, color=self.color(block, face)
         )
 
-    def add_multi(self, position: typing.Tuple[int, int, int], block, faces, batches):
-        return self.layered_models[block.height - 1].add_face_to_batch(
+    def add_multi(self, position: typing.Tuple[int, int, int], block, faces: int, batches):
+        return self.layered_models[block.height - 1].add_faces_to_batch(
             batches[1],
             block.position,
-            [face.index for face in faces],
-            color=self.color(block, faces[0]),
+            faces,
+            color=self.color(block, faces),
         )

--- a/mcpython/client/rendering/model/BlockState.py
+++ b/mcpython/client/rendering/model/BlockState.py
@@ -172,8 +172,8 @@ class MultiPartDecoder(IBlockStateDecoder):
         previous=None,
     ) -> typing.Iterable:
         state = instance.get_model_state()
-        prepared_vertex, prepared_texture, prepared_tint, box_model = (
-            ([], [], [], None) if previous is None else (*previous, None)
+        prepared_vertex, prepared_texture, prepared_tint, prepare_vertex_elements, box_model = (
+            ([], [], [], [], None) if previous is None else (*previous, None)
         )
         box_model = self.prepare_rendering_data_multi_face(
             box_model,
@@ -182,6 +182,7 @@ class MultiPartDecoder(IBlockStateDecoder):
             prepared_texture,
             prepared_vertex,
             prepared_tint,
+            prepare_vertex_elements,
             state,
             batch=batch,
         )
@@ -355,6 +356,7 @@ class MultiPartDecoder(IBlockStateDecoder):
         prepared_texture,
         prepared_vertex,
         prepared_tint,
+        prepare_vertex_elements,
         state,
         batch: pyglet.graphics.Batch = None,
     ):
@@ -375,7 +377,7 @@ class MultiPartDecoder(IBlockStateDecoder):
                         instance.position,
                         config,
                         faces,
-                        previous=(prepared_vertex, prepared_texture, prepared_tint),
+                        previous=(prepared_vertex, prepared_texture, prepared_tint, prepare_vertex_elements),
                         batch=batch,
                     )
 
@@ -388,7 +390,7 @@ class MultiPartDecoder(IBlockStateDecoder):
                         instance.position,
                         config,
                         faces,
-                        previous=(prepared_vertex, prepared_texture, prepared_tint),
+                        previous=(prepared_vertex, prepared_texture, prepared_tint, prepare_vertex_elements),
                         batch=batch,
                     )
 

--- a/mcpython/client/rendering/model/BoxModel.py
+++ b/mcpython/client/rendering/model/BoxModel.py
@@ -13,6 +13,7 @@ This project is not official by mojang and does not relate to it.
 """
 import itertools
 import typing
+from functools import reduce
 
 import deprecation
 
@@ -27,6 +28,7 @@ from mcpython.client.rendering.model.api import (
     IBlockStateRenderingTarget,
 )
 from mcpython.client.rendering.model.util import SIDE_ORDER, UV_INDICES, UV_ORDER
+from mcpython.engine import logger
 from mcpython.util.annotation import onlyInClient
 from mcpython.util.enums import EnumSide
 from mcpython.util.vertex import VertexProvider
@@ -50,11 +52,12 @@ class BoxModel(AbstractBoxModel):
         self.model = None
         self.data = None
         self.tex_data = None
-        self.inactive = None
+        self.inactive = 0b111111
         self.box_position = self.rotation = self.rotation_center = (0, 0, 0)
         self.box_size = 1, 1, 1
 
         self.faces = [None] * 6
+        self.animated_faces: typing.List[int | None] = [None] * 6
         self.face_tint_index = [-1] * 6
 
         self.texture_region: typing.List[typing.Tuple[float, float, float, float]] = [
@@ -126,9 +129,13 @@ class BoxModel(AbstractBoxModel):
             if name in data["faces"]:
                 f = data["faces"][name]
                 var = f["texture"]
-                self.faces[face.index] = (
-                    model.get_texture_position(var) if model is not None else None
-                )
+                position = model.get_texture_position(var) if model is not None else None
+
+                if isinstance(position, int):
+                    self.animated_faces[face.index] = position
+                else:
+                    self.faces[face.index] = position
+
                 index = SIDE_ORDER.index(face)
 
                 if "uv" in f:
@@ -165,9 +172,23 @@ class BoxModel(AbstractBoxModel):
         if atlas is None:
             atlas = self.model.texture_atlas
 
-        up, down, north, east, south, west = array = tuple(
-            [self.faces[i] if self.faces[i] is not None else (0, 0) for i in range(6)]
-        )
+        from mcpython.client.texture.AnimationManager import animation_manager
+
+        data = [(0, 0)] * 6
+
+        for i in range(6):
+            if self.faces[i] is not None:
+                data[i] = self.faces[i]
+                continue
+
+            if self.animated_faces[i] is not None:
+                data[i] = animation_manager.get_position_for_texture(self.animated_faces[i])
+                continue
+
+        if any(self.animated_faces):
+            print(self.model.name, data)
+
+        up, down, north, east, south, west = array = tuple(data)
 
         self.tex_data = mcpython.util.math.tex_coordinates_better(
             up,
@@ -181,11 +202,14 @@ class BoxModel(AbstractBoxModel):
             rotation=self.texture_region_rotate,
         )
 
-        self.inactive = {
-            face: array[i] == (0, 0) or array[i] is None
+        self.inactive = reduce(lambda a, b: a | b, [0] + [
+            face.bitflag
             for i, face in enumerate(mcpython.util.enums.EnumSide.iterate())
-        }
+            if array[i] == (0, 0) or array[i] is None
+        ])
         self.atlas = atlas
+
+        # print(self.model.name, self.inactive, self.animated_faces, data)
 
         self.enable_alpha = not shared.tag_handler.has_entry_tag(
             self.model.name, "rendering", "#minecraft:alpha"
@@ -239,7 +263,7 @@ class BoxModel(AbstractBoxModel):
         previous: typing.Tuple[
             typing.List[float], typing.List[float], typing.List[float]
         ] = None,
-        batch: pyglet.graphics.Batch = None,
+        batch: pyglet.graphics.Batch | typing.List[pyglet.graphics.Batch] = None,
     ) -> typing.Tuple[typing.List[float], typing.List[float], typing.List[float]]:
         """
         Util method for getting the box data for a block (vertices and uv's)
@@ -254,6 +278,9 @@ class BoxModel(AbstractBoxModel):
         vertex = self.get_vertex_variant(rotation, position)
         collected_data = ([], [], [], []) if previous is None else previous
 
+        if previous and len(previous) != 4:
+            raise RuntimeError
+
         faces = EnumSide.rotate_bitmap(EnumSide.rotate_bitmap(faces, rotation), (0, -90, 0))
 
         for face in mcpython.util.enums.EnumSide.iterate():
@@ -266,8 +293,50 @@ class BoxModel(AbstractBoxModel):
             if face.bitflag & faces:
                 if (
                     not mcpython.common.config.USE_MISSING_TEXTURES_ON_MISS_TEXTURE
-                    and self.inactive[face.rotate(rotation)]
+                    and self.inactive & face.rotate(rotation).bitflag
                 ):
+                    continue
+
+                if vertex is None or self.tex_data is None:
+                    logger.println("something is wrong @"+str(position), vertex, self.tex_data, bin(self.inactive))
+                    continue
+
+                if self.animated_faces[i2] is not None:
+                    print(self.model.name, position, self.animated_faces, batch)
+
+                    if batch is not None:
+                        from mcpython.client.texture.AnimationManager import animation_manager
+
+                        group = animation_manager.get_group_for_texture(self.animated_faces[i2])
+
+                        print(group, [
+                            animation_manager.get_position_for_texture(self.animated_faces[i])
+                            if self.animated_faces[i] is not None else None
+                            for i in range(6)
+                        ])
+                        print(self.tex_data[i2])
+
+                        if type(batch) == list:
+                            batch2 = (
+                                batch[0] if self.model is not None and self.enable_alpha else batch[1]
+                            )
+                        else:
+                            batch2 = batch
+
+                        collected_data[3].append(batch2.add(
+                            4,
+                            pyglet.gl.GL_QUADS,
+                            group,
+                            ("v3d/static", vertex[i]),
+                            ("t2f/static", self.tex_data[i2]),
+                            ("c4f/static", (1,) * 16
+                                if self.face_tint_index[face.index] == -1
+                                else instance.get_tint_for_index(self.face_tint_index[face.index])
+                                * 4),
+                        ))
+                    else:
+                        logger.println("skipping animated texture @"+str(position)+"; batch not present")
+
                     continue
 
                 collected_data[0].extend(vertex[i])
@@ -333,7 +402,7 @@ class BoxModel(AbstractBoxModel):
             ):
                 if (
                     not mcpython.common.config.USE_MISSING_TEXTURES_ON_MISS_TEXTURE
-                    and self.inactive[face.rotate(rotation)]
+                    and self.inactive & face.rotate(rotation).bitflag
                 ):
                     continue
 

--- a/mcpython/client/rendering/model/BoxModel.py
+++ b/mcpython/client/rendering/model/BoxModel.py
@@ -751,6 +751,7 @@ class RawBoxModel(AbstractBoxModel):
             ("t2f/static", self.texture_cache),
         )
 
+    @deprecation.deprecated()
     def add_face_to_batch(
         self,
         batch: pyglet.graphics.Batch,
@@ -764,6 +765,32 @@ class RawBoxModel(AbstractBoxModel):
         for i in range(6):
             if i in face if isinstance(face, int) else face.index == i:
                 continue
+
+            t = self.texture_cache[i * 8 : i * 8 + 8]
+            v = vertices[i * 12 : i * 12 + 12]
+            result.append(
+                batch.add(
+                    4,
+                    pyglet.gl.GL_QUADS,
+                    self.texture,
+                    ("v3d/static", v),
+                    ("t2f/static", t),
+                )
+            )
+        return result
+
+    def add_faces_to_batch(
+        self,
+        batch: pyglet.graphics.Batch,
+        position: typing.Tuple[float, float, float],
+        faces: int,
+        rotation=(0, 0, 0),
+        rotation_center=(0, 0, 0),
+    ):
+        vertices = self.get_vertices(position, rotation, rotation_center)
+        result = []
+        for i, face in enumerate(EnumSide.iterate()):
+            if not face.bitflag & faces: continue
 
             t = self.texture_cache[i * 8 : i * 8 + 8]
             v = vertices[i * 12 : i * 12 + 12]
@@ -828,6 +855,7 @@ class MutableRawBoxModel(RawBoxModel):
         vertices = self.get_vertices(position, rotation, rotation_center)
         previous.vertices[:] = vertices
 
+    @deprecation.deprecated()
     def add_face_to_batch(
         self,
         batch: pyglet.graphics.Batch,
@@ -844,6 +872,33 @@ class MutableRawBoxModel(RawBoxModel):
                 if isinstance(face, int)
                 else (face is not None and face.index == i)
             ):
+                continue
+
+            t = self.texture_cache[i * 8 : i * 8 + 8]
+            v = vertices[i * 12 : i * 12 + 12]
+            result.append(
+                batch.add(
+                    4,
+                    pyglet.gl.GL_QUADS,
+                    self.texture,
+                    ("v3f/dynamic", v),
+                    ("t2f/dynamic", t),
+                )
+            )
+        return result
+
+    def add_faces_to_batch(
+        self,
+        batch: pyglet.graphics.Batch,
+        position: typing.Tuple[float, float, float],
+        faces: int,
+        rotation=(0, 0, 0),
+        rotation_center=(0, 0, 0),
+    ):
+        vertices = self.get_vertices(position, rotation, rotation_center)
+        result = []
+        for i, face in enumerate(EnumSide.iterate()):
+            if not face.bitflag & faces:
                 continue
 
             t = self.texture_cache[i * 8 : i * 8 + 8]
@@ -900,6 +955,7 @@ class ColoredRawBoxModel(RawBoxModel):
             ("c4f", color * 24),
         )
 
+    @deprecation.deprecated()
     def add_face_to_batch(
         self,
         batch: pyglet.graphics.Batch,
@@ -917,6 +973,35 @@ class ColoredRawBoxModel(RawBoxModel):
                 if isinstance(face, int)
                 else (face is not None and face.index == i)
             ):
+                continue
+
+            t = self.texture_cache[i * 8 : i * 8 + 8]
+            v = vertices[i * 12 : i * 12 + 12]
+            result.append(
+                batch.add(
+                    4,
+                    pyglet.gl.GL_QUADS,
+                    self.texture,
+                    ("v3d/static", v),
+                    ("t2f/static", t),
+                    ("c4f", color * 4),
+                )
+            )
+        return result
+
+    def add_faces_to_batch(
+        self,
+        batch: pyglet.graphics.Batch,
+        position: typing.Tuple[float, float, float],
+        faces: int,
+        rotation=(0, 0, 0),
+        rotation_center=(0, 0, 0),
+        color=(1, 1, 1, 1),
+    ):
+        vertices = self.get_vertices(position, rotation, rotation_center)
+        result = []
+        for i, face in enumerate(EnumSide.iterate()):
+            if not face.bitflag & faces:
                 continue
 
             t = self.texture_cache[i * 8 : i * 8 + 8]

--- a/mcpython/client/rendering/model/BoxModel.py
+++ b/mcpython/client/rendering/model/BoxModel.py
@@ -186,11 +186,7 @@ class BoxModel(AbstractBoxModel):
                 coords = animation_manager.get_position_for_texture(self.animated_faces[i])
                 size = animation_manager.get_atlas_size_for_texture(self.animated_faces[i])
                 self.animated_texture_coords[i] = mcpython.util.math.tex_coordinates(*coords, size=size, region=self.texture_region[i], rot=self.texture_region_rotate[i])
-                print(size, mcpython.util.math.tex_coordinates(*coords, size=size, region=self.texture_region[i], rot=self.texture_region_rotate[i]))
                 continue
-
-        if any(self.animated_faces):
-            print(self.model.name, data)
 
         self.tex_data = mcpython.util.math.tex_coordinates_better(
             *data,
@@ -205,8 +201,6 @@ class BoxModel(AbstractBoxModel):
             if data[i] in (None, (0, 0)) and self.animated_texture_coords[i] in (None, (0, 0))
         ])
         self.atlas = atlas
-
-        # print(self.model.name, self.inactive, self.animated_faces, data)
 
         self.enable_alpha = not shared.tag_handler.has_entry_tag(
             self.model.name, "rendering", "#minecraft:alpha"
@@ -299,19 +293,10 @@ class BoxModel(AbstractBoxModel):
                     continue
 
                 if self.animated_faces[i2] is not None:
-                    print(self.model.name, position, self.animated_faces, batch)
-
                     if batch is not None:
                         from mcpython.client.texture.AnimationManager import animation_manager
 
                         group = animation_manager.get_group_for_texture(self.animated_faces[i2])
-
-                        print(group, [
-                            animation_manager.get_position_for_texture(self.animated_faces[i])
-                            if self.animated_faces[i] is not None else None
-                            for i in range(6)
-                        ])
-                        print(self.tex_data[i2])
 
                         if type(batch) == list:
                             batch2 = (

--- a/mcpython/client/rendering/model/ModelHandler.py
+++ b/mcpython/client/rendering/model/ModelHandler.py
@@ -413,6 +413,7 @@ class ModelHandler:
         mcpython.client.rendering.model.BlockState.BlockStateContainer.TO_CREATE.clear()
         mcpython.client.rendering.model.BlockState.BlockStateContainer.NEEDED.clear()
 
+        logger.println("walking across block states...")
         for (
             directory,
             modname,
@@ -423,6 +424,7 @@ class ModelHandler:
                 directory, modname, immediate=True
             )
 
+        logger.println("walking across located block states...")
         for (
             data,
             name,
@@ -435,6 +437,7 @@ class ModelHandler:
         shared.event_handler.call("minecraft:data:blockstates:custom_injection", self)
         shared.event_handler.call("minecraft:data:models:custom_injection", self)
 
+        logger.println("walking across requested models...")
         self.build(immediate=True)
         self.process_models(immediate=True)
         animation_manager.bake()

--- a/mcpython/client/rendering/model/ModelHandler.py
+++ b/mcpython/client/rendering/model/ModelHandler.py
@@ -29,6 +29,7 @@ import mcpython.util.math
 from mcpython import shared
 from mcpython.client.rendering.model.api import IBlockStateRenderingTarget
 from mcpython.client.rendering.model.BoxModel import ColoredRawBoxModel
+from mcpython.client.texture.AnimationManager import animation_manager
 from mcpython.engine import logger
 from mcpython.util.enums import EnumSide
 
@@ -436,6 +437,7 @@ class ModelHandler:
 
         self.build(immediate=True)
         self.process_models(immediate=True)
+        animation_manager.bake()
 
         logger.println("finished!")
 

--- a/mcpython/client/texture/AnimationManager.py
+++ b/mcpython/client/texture/AnimationManager.py
@@ -1,0 +1,133 @@
+"""
+mcpython - a minecraft clone written in python licenced under the MIT-licence
+(https://github.com/mcpython4-coding/core)
+
+Contributors: uuk, xkcdjerry (inactive)
+
+Based on the game of fogleman (https://github.com/fogleman/Minecraft), licenced under the MIT-licence
+Original game "minecraft" by Mojang Studios (www.minecraft.net), licenced under the EULA
+(https://account.mojang.com/documents/minecraft_eula)
+Mod loader inspired by "Minecraft Forge" (https://github.com/MinecraftForge/MinecraftForge) and similar
+
+This project is not official by mojang and does not relate to it.
+"""
+import typing
+
+import PIL.Image
+import pyglet
+from pyglet.graphics import TextureGroup
+
+import mcpython.engine.ResourceLoader
+from mcpython import shared
+from mcpython.engine import logger
+from mcpython.util.texture import to_pyglet_image
+
+
+class AnimationController:
+    def __init__(self, frames: int, timing: int):
+        self.frames = frames
+        self.timing = timing
+        from .TextureAtlas import MISSING_TEXTURE, TextureAtlas
+        self.group: typing.Optional[pyglet.graphics.TextureGroup] = pyglet.graphics.TextureGroup(to_pyglet_image(MISSING_TEXTURE).get_texture())
+        self.ticks_since_change = 0
+        self.atlas_index = 0
+
+        self.textures = [None] * frames
+        self.atlases = [
+            TextureAtlas(size=(32, 32))  # size=(4, 4))  # todo: enable and fix this somehow in BoxModel breaking down
+            for _ in range(frames)
+        ]
+
+        self.remaining_ticks = 0
+
+    def add_texture(self, image: PIL.Image, lookup: typing.List[int]):
+        if len(lookup) != self.frames: raise ValueError(lookup, len(lookup), self.frames)
+
+        atlas = self.atlases[0]
+        width = image.width
+
+        # todo: split textures beforehand!
+
+        pos = atlas.add_image(image.crop((0, lookup[0]*width, width, (lookup[0]+1)*width)))
+
+        for atlas, index in zip(self.atlases[1:], lookup[1:]):
+            atlas.add_image(image.crop((0, index*width, width, (index+1)*width)))
+
+        return pos
+
+    def bake(self):
+        for i, atlas in enumerate(self.atlases):
+            self.textures[i] = atlas.get_pyglet_texture()
+            # atlas.texture.save(shared.build+f"/atlas_{self.frames}_{self.timing}_{i}.png")
+        self.group = TextureGroup(self.textures[0])
+
+    def tick(self, ticks: float):
+        self.ticks_since_change += ticks
+        swaps = int(self.ticks_since_change // self.timing)
+        self.ticks_since_change %= self.timing
+
+        self.atlas_index = int((self.atlas_index + swaps) % self.frames)
+        self.group.texture = self.textures[self.atlas_index]
+
+
+class AnimationManager:
+    def __init__(self):
+        self.controllers: typing.Dict[typing.Tuple[int, int], AnimationController] = {}
+        self.positions: typing.List[typing.Tuple[int, int]] = []
+        self.texture2controller: typing.List[AnimationController] = []
+        self.texture_lookup: typing.Dict[str, int] = {}
+
+    def prepare_animated_texture(self, location: str) -> int:
+        if location in self.texture_lookup: return self.texture_lookup[location]
+
+        texture = mcpython.engine.ResourceLoader.read_image(location)
+
+        if ":" in location:
+            t_location = "assets/{}/textures/{}.png".format(*location.split(":"))
+        elif not location.endswith(".png"):
+            t_location = "assets/minecraft/textures/{}.png".format(location)
+        else:
+            t_location = location
+
+        if not mcpython.engine.ResourceLoader.exists(t_location + ".mcmeta"):
+            logger.println("skipping animated texture @"+location+" / "+t_location)
+            return -1
+
+        meta: dict = mcpython.engine.ResourceLoader.read_json(t_location+".mcmeta")["animation"]
+
+        if "frames" not in meta:
+            meta["frames"] = list(range(texture.height // texture.width))
+
+        atlas = self.get_atlas_for_spec(len(meta["frames"]), meta.setdefault("frametime", 1))
+        self.positions.append(atlas.add_texture(texture, meta["frames"]))
+        self.texture2controller.append(atlas)
+
+        self.texture_lookup[location] = len(self.positions) - 1
+
+        return len(self.positions) - 1
+
+    def get_atlas_for_spec(self, frames: int, timing: int) -> AnimationController:
+        if (frames, timing) in self.controllers:
+            return self.controllers[(frames, timing)]
+
+        controller = AnimationController(frames, timing)
+        self.controllers[(frames, timing)] = controller
+        return controller
+
+    def get_group_for_texture(self, texture: int):
+        return self.texture2controller[texture].group
+
+    def get_position_for_texture(self, texture: int):
+        return self.positions[texture] if texture != -1 else (0, 0)
+
+    def tick(self, ticks: float):
+        for controller in self.controllers.values():
+            controller.tick(ticks)
+
+    def bake(self):
+        for controller in self.controllers.values():
+            controller.bake()
+
+
+animation_manager = AnimationManager()
+

--- a/mcpython/client/texture/AnimationManager.py
+++ b/mcpython/client/texture/AnimationManager.py
@@ -34,7 +34,7 @@ class AnimationController:
 
         self.textures = [None] * frames
         self.atlases = [
-            TextureAtlas(size=(32, 32))  # size=(4, 4))  # todo: enable and fix this somehow in BoxModel breaking down
+            TextureAtlas(size=(4, 4))
             for _ in range(frames)
         ]
 
@@ -119,6 +119,9 @@ class AnimationManager:
 
     def get_position_for_texture(self, texture: int):
         return self.positions[texture] if texture != -1 else (0, 0)
+
+    def get_atlas_size_for_texture(self, texture: int):
+        return self.texture2controller[texture].atlases[0].size
 
     def tick(self, ticks: float):
         for controller in self.controllers.values():

--- a/mcpython/client/texture/TextureAtlas.py
+++ b/mcpython/client/texture/TextureAtlas.py
@@ -22,6 +22,7 @@ import pyglet
 from mcpython import shared
 from mcpython.engine import logger
 from mcpython.util.annotation import onlyInClient
+import mcpython.util.texture
 
 # We need the missing texture image only on the client, the server will never need this
 if shared.IS_CLIENT and not shared.IS_TEST_ENV:
@@ -238,6 +239,9 @@ class TextureAtlas:
         return count <= self.size[0] * self.size[1] - len(self.images) or count <= len(
             self.free_space
         )
+
+    def get_pyglet_texture(self):
+        return mcpython.util.texture.to_pyglet_image(self.texture).get_texture()
 
 
 handler = TextureAtlasGenerator()

--- a/mcpython/common/event/TickHandler.py
+++ b/mcpython/common/event/TickHandler.py
@@ -22,6 +22,9 @@ import pyglet
 from mcpython import shared
 from mcpython.engine import logger
 
+if shared.IS_CLIENT:
+    from mcpython.client.texture.AnimationManager import animation_manager
+
 
 class TickHandler:
     """
@@ -78,6 +81,7 @@ class TickHandler:
         if shared.IS_CLIENT:
             shared.event_handler.call("tickhandler:client")
             shared.NETWORK_MANAGER.fetch_as_client()
+            animation_manager.tick(dt * 20)
         else:
             shared.event_handler.call("tickhandler:server")
             shared.NETWORK_MANAGER.fetch_as_server()

--- a/mcpython/common/state/WorldLoadingProgressState.py
+++ b/mcpython/common/state/WorldLoadingProgressState.py
@@ -111,7 +111,7 @@ class WorldLoadingProgress(AbstractState.AbstractState):
         logger.println("[WORLD LOADING][INFO] initializing dimension info")
         shared.dimension_handler.init_dims()
 
-        logger.println("(WORLD LOADING)[INFO] preparing for world loading...")
+        logger.println("[WORLD LOADING][INFO] preparing for world loading...")
         try:
             shared.world.save_file.load_world()
 

--- a/mcpython/shared.py
+++ b/mcpython/shared.py
@@ -36,7 +36,7 @@ build = (
     if "--build-folder" not in sys.argv
     else sys.argv[sys.argv.index("--build-folder") + 1]
 )
-tmp = tempfile.TemporaryDirectory()
+tmp = tempfile.TemporaryDirectory(prefix="mcpython-4")
 
 data_gen = (
     "--data-gen" in sys.argv or "--invalidate-cache" in sys.argv

--- a/mcpython/util/libmodifiers.py
+++ b/mcpython/util/libmodifiers.py
@@ -67,4 +67,73 @@ patchAsyncSystem()
 
 
 if shared.IS_CLIENT:
+    def replacement_update_draw_list(self):
+        import pyglet
+
+        def visit(group):
+            draw_list = []
+
+            if group not in self.group_map:
+                self._add_group(group)
+
+            # Draw domains using this group
+            domain_map = self.group_map[group]
+            for (formats, mode, indexed), domain in list(domain_map.items()):
+                # Remove unused domains from batch
+                if domain._is_empty():
+                    del domain_map[(formats, mode, indexed)]
+                    continue
+                draw_list.append(
+                    (lambda d, m: lambda: d.draw(m))(domain, mode))
+
+            # Sort and visit child groups of this group
+            children = self.group_children.get(group)
+            if children:
+                children.sort()
+                for child in list(children):
+                    if child.visible:
+                        draw_list.extend(visit(child))
+
+            if children or domain_map:
+                return [group.set_state] + draw_list + [group.unset_state]
+            else:
+                # Remove unused group from batch
+                del self.group_map[group]
+                group._assigned_batches.remove(self)
+                if group.parent:
+                    self.group_children[group.parent].remove(group)
+                try:
+                    del self.group_children[group]
+                except KeyError:
+                    pass
+                try:
+                    self.top_groups.remove(group)
+                except ValueError:
+                    pass
+
+                return []
+
+        self._draw_list = []
+
+        self.top_groups.sort()
+        for group in list(self.top_groups):
+            if group.visible:
+                self._draw_list.extend(visit(group))
+
+        self._draw_list_dirty = False
+
+        if pyglet.graphics._debug_graphics_batch:
+            self._dump_draw_list()
+
+
+    def patchPygletRendering():
+        logger.println("[MIXIN][PYGLET] applying pyglet mixins")
+        import pyglet
+
+        method = FunctionPatcher(pyglet.graphics.Batch._update_draw_list)
+
+        method.overrideFrom(FunctionPatcher(replacement_update_draw_list))
+        method.applyPatches()
+
     applyPillowPatches()
+    patchPygletRendering()


### PR DESCRIPTION
How does it work?

We create for animated block textures a texture atlas for each block animation type
(identified by frame count and frame timing), so it is easier to animate later.

We take a special route in block rendering and model baking for animated textures.
The animated atlas groups are bound onces per face, and the underlying pyglet rendering group
is simply exchanged. 
(This part should be a shader in the future)

In order to get it working, as pyglet does not allow modifying groups at runtime by default,
we need to patch a small additional check into pyglet's internal batch system

WARNING: highly unstable code